### PR TITLE
1.1 v fix (#60)

### DIFF
--- a/scm_v3c/optical.c
+++ b/scm_v3c/optical.c
@@ -94,7 +94,10 @@ void optical_32_isr(void) {
 // optical data transfer Need to make sure a new bit has been clocked in prior
 // to returning from this ISR, or else it will immediately execute again
 void optical_sfd_isr(void) {
-    int32_t t;
+    // 1.1V (helps reorder assembly code)
+		uint32_t dummy = 0;
+	
+		int32_t t;
     uint32_t rdata_lsb, rdata_msb;
     uint32_t count_LC, count_32k, count_2M, count_HFclock, count_IF;
 

--- a/scm_v3c/radio.c
+++ b/scm_v3c/radio.c
@@ -226,6 +226,10 @@ void repeat_rx_tx(repeat_rx_tx_params_t repeat_rx_tx_params) {
     uint8_t cfg_coarse_stop;
     uint8_t cfg_mid_stop;
     uint8_t cfg_fine_stop;
+		
+		// 1.1V (helps reorder assembly code)
+		uint8_t *txPacket_fix = repeat_rx_tx_params.txPacket;
+		uint8_t pkt_len_fix = repeat_rx_tx_params.pkt_len;
 
     int pkt_count = 0;
     char* radio_mode_string;
@@ -258,11 +262,14 @@ void repeat_rx_tx(repeat_rx_tx_params_t repeat_rx_tx_params) {
         cfg_mid_stop = repeat_rx_tx_params.sweep_lc_mid_end;
         cfg_fine_start = repeat_rx_tx_params.sweep_lc_fine_start;
         cfg_fine_stop = repeat_rx_tx_params.sweep_lc_fine_end;
-        printf("Sweeping %s from Coarse: %d-%d  Mid: %d-%d  Fine: %d-%d\n",
-               radio_mode_string, cfg_coarse_start, cfg_coarse_stop,
-               cfg_mid_start, cfg_mid_stop, cfg_fine_start, cfg_fine_stop);
+        // 1.1V probably can be added back in if broken down
+				//printf("Sweeping %s from Coarse: %d-%d  Mid: %d-%d  Fine: %d-%d\n",
+        //       radio_mode_string, cfg_coarse_start, cfg_coarse_stop,
+        //       cfg_mid_start, cfg_mid_stop, cfg_fine_start, cfg_fine_stop);
     }
-
+		// 1.1V
+		__asm("NOP");
+		
     while (1) {
         // loop through all LC configuration
         for (cfg_coarse = cfg_coarse_start; cfg_coarse < cfg_coarse_stop;
@@ -290,12 +297,14 @@ void repeat_rx_tx(repeat_rx_tx_params_t repeat_rx_tx_params) {
                             repeat_rx_tx_params.txPacket[i] = ' ';
                         }
 
+                        // 1.1V
+												txPacket_fix = repeat_rx_tx_params.txPacket;
+												__asm("NOP");
+												// 1.1V
                         repeat_rx_tx_params.fill_tx_packet(
-                            repeat_rx_tx_params.txPacket,
-                            repeat_rx_tx_params.pkt_len, state);
-
-                        send_packet(repeat_rx_tx_params.txPacket,
-                                    repeat_rx_tx_params.pkt_len);
+                            txPacket_fix, pkt_len_fix, state);
+												// 1.1V
+                        send_packet(txPacket_fix, pkt_len_fix);
                     }
 
                     pkt_count += 1;

--- a/scm_v3c/retarget.c
+++ b/scm_v3c/retarget.c
@@ -13,10 +13,6 @@ struct __FILE {
 FILE __stdout = {(unsigned char*)APB_UART_BASE};
 FILE __stdin = {(unsigned char*)APB_UART_BASE};
 
-int fputc(int ch, FILE* f) { return (uart_out(ch)); }
-
-int fgetc(FILE* f) { return (uart_in()); }
-
 int ferror(FILE* f) { return 0; }
 
 int uart_out(int ch) {
@@ -34,6 +30,10 @@ int uart_in() {
     uart_out(ch);
     return ((int)ch);
 }
+
+int fputc(int ch, FILE* f) { return (uart_out(ch)); }
+
+int fgetc(FILE* f) { return (uart_in()); }
 
 void _ttywrch(int ch) { fputc(ch, &__stdout); }
 

--- a/scm_v3c/scm3c_hw_interface.c
+++ b/scm_v3c/scm3c_hw_interface.c
@@ -1441,6 +1441,9 @@ void set_asc_bit(unsigned int position) {
 
     scm3c_hw_interface_vars.ASC[index] |=
         0x80000000 >> (position - (index << 5));
+    
+    // Needed for no 1.1V -> VDDD fix
+    __asm("NOP");
 
     // Possibly more efficient
     // scm3c_hw_interface_vars.ASC[position/32] |= 1 << (position%32);
@@ -1453,6 +1456,9 @@ void clear_asc_bit(unsigned int position) {
 
     scm3c_hw_interface_vars.ASC[index] &=
         ~(0x80000000 >> (position - (index << 5)));
+
+    // Needed for no 1.1V -> VDDD fix
+    __asm("NOP");
 
     // Possibly more efficient
     // scm3c_hw_interface_vars.ASC[position/32] &= ~(1 << (position%32));
@@ -1470,9 +1476,13 @@ void LC_FREQCHANGE(int coarse, int mid, int fine) {
     //        none, it programs the LC radio frequency immediately
 
     // mask to ensure that the coarse, mid, and fine are actually 5-bit
+		// 1.1V (NOP)
     char coarse_m = (char)(coarse & 0x1F);
+		__asm("NOP");
     char mid_m = (char)(mid & 0x1F);
-    char fine_m = (char)(fine & 0x1F);
+		__asm("NOP");
+		char fine_m = (char)(fine & 0x1F);
+		__asm("NOP");
 
     // flip the bit order to make it fit more easily into the ACFG registers
     unsigned int coarse_f = (unsigned int)(flipChar(coarse_m));


### PR DESCRIPTION
* set/clear_asc_bit fix (#53)

Adding a NOP at the end of the set_asc_bit and clear_asc_bit function allows the chip to fully initialize now.

* Revert "set/clear_asc_bit fix (#53)"

This reverts commit aa18d8aff8336a236ce8183e7962228b84dae726.

* set/clear_asc_bit fix

Adding a NOP at the end of the set_asc_bit and clear_asc_bit function allows the chip to fully initialize now.

* freq_sweep_tx_simple Fixed + Calibration Fix

Made changes to repeat_rx_tx() and LC_FEQCHANGE() function to fix simple sweep project. Added dummy variable to optical_sfd_isr() function that fixes the chip calibration.

* squash warnings

Remove warnings in Keil by reordering.